### PR TITLE
feat: added spiderman palette

### DIFF
--- a/spiderman/spiderman.json
+++ b/spiderman/spiderman.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#F5453F",
+    "mOnPrimary": "#0A1E42",
+    "mSecondary": "#3D7EFF",
+    "mOnSecondary": "#0A1E42",
+    "mTertiary": "#F5453F",
+    "mOnTertiary": "#0A1E42",
+    "mError": "#FF6B3D",
+    "mOnError": "#0A1E42",
+    "mSurface": "#0B2454",
+    "mOnSurface": "#EAF0FB",
+    "mSurfaceVariant": "#102D63",
+    "mOnSurfaceVariant": "#9BB4DC",
+    "mOutline": "#4E71A8",
+    "mShadow": "#000000",
+    "mHover": "#F5453F",
+    "mOnHover": "#0A1E42",
+    "terminal": {
+      "background": "#0B2454",
+      "foreground": "#EAF0FB",
+      "cursor": "#F5453F",
+      "cursorText": "#0A1E42",
+      "selectionBg": "#3D7EFF",
+      "selectionFg": "#0A1E42",
+      "normal": {
+        "black": "#0B2454",
+        "red": "#C93D45",
+        "green": "#C93D45",
+        "yellow": "#F5453F",
+        "blue": "#C93D45",
+        "magenta": "#C93D45",
+        "cyan": "#C93D45",
+        "white": "#EAF0FB"
+      },
+      "bright": {
+        "black": "#4E71A8",
+        "red": "#F5453F",
+        "green": "#FF6B6B",
+        "yellow": "#FF6B3D",
+        "blue": "#FF6B6B",
+        "magenta": "#FF6B6B",
+        "cyan": "#FF6B6B",
+        "white": "#FFFFFF"
+      }
+    }
+  },
+  "light": {
+    "mPrimary": "#C9282E",
+    "mOnPrimary": "#F8FAFF",
+    "mSecondary": "#5C8FEF",
+    "mOnSecondary": "#0B2148",
+    "mTertiary": "#C9282E",
+    "mOnTertiary": "#F8FAFF",
+    "mError": "#B33418",
+    "mOnError": "#F8FAFF",
+    "mSurface": "#24478A",
+    "mOnSurface": "#F8FAFF",
+    "mSurfaceVariant": "#1D3D75",
+    "mOnSurfaceVariant": "#C3D2EC",
+    "mOutline": "#3A5FA3",
+    "mShadow": "#0B2148",
+    "mHover": "#C9282E",
+    "mOnHover": "#F8FAFF",
+    "terminal": {
+      "background": "#24478A",
+      "foreground": "#F8FAFF",
+      "cursor": "#C9282E",
+      "cursorText": "#F8FAFF",
+      "selectionBg": "#0B2148",
+      "selectionFg": "#F8FAFF",
+      "normal": {
+        "black": "#102A52",
+        "red": "#A82430",
+        "green": "#A82430",
+        "yellow": "#C9282E",
+        "blue": "#A82430",
+        "magenta": "#A82430",
+        "cyan": "#A82430",
+        "white": "#F8FAFF"
+      },
+      "bright": {
+        "black": "#4E71A8",
+        "red": "#C9282E",
+        "green": "#E0443C",
+        "yellow": "#E0443C",
+        "blue": "#E0443C",
+        "magenta": "#E0443C",
+        "cyan": "#E0443C",
+        "white": "#FFFFFF"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

I found this cool spidey wallpaper and wants a good color theme to go with it. None of the palettes or the wallpaper generated colors complimented it the way I wanted. I wanted something that screams spider-man so I went and made this spider-man classic blue and red colored palette.

## Screenshots

Please attach screenshots of your palette applied in Noctalia for both themes:

### Dark theme
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/3c7e0d53-7f6c-488a-9cbb-e520850655aa" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/75fb126a-f8a5-4ab3-9141-0464d1d96529" />

### With pure black turned on
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/52473970-64c1-4691-a6af-e5b01a7d8895" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/5dda9bf5-dbe1-44ce-a913-233e72d01788" />


### Light theme
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/b2030181-1a25-4a97-9fa2-f89a5f421412" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/106aa684-b8c5-4093-a011-214023d42468" />


## Checklist

- [ yes ] I have tested my palette in Noctalia with the **dark** theme
- [ yes ] I have tested my palette in Noctalia with the **light** theme
- [ yes ] Screenshots for both themes are attached above
