### PR TITLE
feat: add Koneko palette

### DIFF
--- a/Koneko/Koneko.json
+++ b/Koneko/Koneko.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#cc7e8b",
+    "mOnPrimary": "#232323",
+    "mSecondary": "#c9afba",
+    "mOnSecondary": "#232323",
+    "mTertiary": "#d4a2ac",
+    "mOnTertiary": "#232323",
+    "mError": "#a05b71",
+    "mOnError": "#f9e1ef",
+    "mSurface": "#232323",
+    "mOnSurface": "#c2c2c2",
+    "mSurfaceVariant": "#292929",
+    "mOnSurfaceVariant": "#929292",
+    "mOutline": "#3c3c3c",
+    "mShadow": "#000000",
+    "mHover": "#d4a2ac",
+    "mOnHover": "#232323",
+    "terminal": {
+      "foreground": "#828282",
+      "background": "#232323",
+      "selectionFg": "#232323",
+      "selectionBg": "#d5a2ab",
+      "cursorText": "#232323",
+      "cursor": "#aaaaaa",
+      "normal": {
+        "black": "#707070",
+        "red": "#d5a2ab",
+        "green": "#b8e1a3",
+        "yellow": "#fbdbc0",
+        "blue": "#8DA8B9",
+        "magenta": "#bfb1c2",
+        "cyan": "#AAC2C5",
+        "white": "#f9e1ef"
+      },
+      "bright": {
+        "black": "#747160",
+		"red": "#DFAAB3",
+		"green": "#C1ECAB",
+		"yellow": "#FFE5C9",
+		"blue": "#94B0C2",
+		"magenta": "#C8B9CB",
+		"cyan": "#B2CBCE",
+        "white": "#fef5fa"
+      }
+    }
+  },
+  "light": {
+    "mPrimary": "#cc7e8b",
+    "mOnPrimary": "#ffffff",
+    "mSecondary": "#000000",
+    "mOnSecondary": "#dac6c8",
+    "mTertiary": "#d4a2ac",
+    "mOnTertiary": "#000000",
+    "mError": "#964860",
+    "mOnError": "#f7efef",
+    "mSurface": "#dac6c8",
+    "mOnSurface": "#000000",
+    "mSurfaceVariant": "#c8aeb9",
+    "mOnSurfaceVariant": "#52504a",
+    "mOutline": "#202020",
+    "mShadow": "#fafafa",
+    "mHover": "#d4a2ac",
+    "mOnHover": "#000000",
+    "terminal": {
+      "foreground": "#000000",
+      "background": "#dac6c8",
+      "selectionFg": "#000000",
+      "selectionBg": "#c7adb8",
+      "cursorText": "#000000",
+      "cursor": "#555555",
+      "normal": {
+        "black": "#000000",
+        "red": "#B64966",
+        "green": "#417a4f",
+        "yellow": "#AE5937",
+        "blue": "#466A81",
+        "magenta": "#95475f",
+        "cyan": "#537279",
+        "white": "#404040"
+      },
+      "bright": {
+        "black": "#606060",
+		"red": "#BF4C6B",
+		"green": "#448052",
+		"yellow": "#B65D39",
+		"blue": "#496F87",
+		"magenta": "#9C4A63",
+		"cyan": "#57777F",
+        "white": "#ffffff"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

A colorful companion to my monochrome Kitten palette (always better to have >1 cats around)

A pretty pink + purple // black + pink palette with proper base16 colors (red-cyan, normal and bright tones; black, grays, white) for when monochrome syntax highlighting just isn't enough :p

I *did* check contrast ratios before making this PR so they all *should* be passing

## Screenshots

### Dark theme
<img width="2304" height="1440" alt="09-07-2026-14:18:52-annotated" src="https://github.com/user-attachments/assets/975279c2-c0db-4420-b59b-6a266990ebed" />
<img width="2304" height="1440" alt="09-07-2026-14:14:20-annotated" src="https://github.com/user-attachments/assets/5cf7330b-e5ac-4f3c-8e7c-0dd98c891eec" />
<img width="2304" height="1440" alt="09-07-2026-14:15:39-annotated" src="https://github.com/user-attachments/assets/dab11dd1-9f91-4c52-bc59-2f1d6e4834ae" />
<img width="429" height="94" alt="image" src="https://github.com/user-attachments/assets/5be7bae5-344e-4640-ab30-fac58bea0661" />

### Light theme
<img width="2304" height="1440" alt="09-07-2026-14:19:40-annotated" src="https://github.com/user-attachments/assets/ce50a76a-3ca6-4e8a-8fb7-232d8014831a" />
<img width="2304" height="1440" alt="09-07-2026-14:20:15-annotated" src="https://github.com/user-attachments/assets/f852a4dc-ef39-46f3-80e0-4d9c07169043" />
<img width="2304" height="1440" alt="09-07-2026-14:13:25-annotated" src="https://github.com/user-attachments/assets/fc947574-60c3-4547-acff-ddd82bb57417" />
<img width="438" height="89" alt="image" src="https://github.com/user-attachments/assets/32a865bf-9cbb-4029-b9bb-abb075e91a7e" />

## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above
