### PR TITLE
fix(ayu): assign terminal colors correctly

### DIFF
--- a/Ayu Blue/Ayu Blue.json
+++ b/Ayu Blue/Ayu Blue.json
@@ -19,8 +19,8 @@
         "black": "#171B24",
         "red": "#ED8274",
         "green": "#87D96C",
-        "yellow": "#6DCBFA",
-        "blue": "#FACC6E",
+        "yellow": "#FACC6E",
+        "blue": "#6DCBFA",
         "magenta": "#DABAFA",
         "cyan": "#90E1C6",
         "white": "#C7C7C7"
@@ -29,8 +29,8 @@
         "black": "#686868",
         "red": "#F28779",
         "green": "#D5FF80",
-        "yellow": "#73D0FF",
-        "blue": "#FFD173",
+        "yellow": "#FFD173",
+        "blue": "#73D0FF",
         "magenta": "#DFBFFF",
         "cyan": "#95E6CB",
         "white": "#FFFFFF"
@@ -65,8 +65,8 @@
         "black": "#000000",
         "red": "#EA6C6D",
         "green": "#6CBF43",
-        "yellow": "#3199E1",
-        "blue": "#ECA944",
+        "yellow": "#ECA944",
+        "blue": "#3199E1",
         "magenta": "#9E75C7",
         "cyan": "#46BA94",
         "white": "#BABABA"
@@ -75,8 +75,8 @@
         "black": "#686868",
         "red": "#F07171",
         "green": "#86B300",
-        "yellow": "#399EE6",
-        "blue": "#F2AE49",
+        "yellow": "#F2AE49",
+        "blue": "#399EE6",
         "magenta": "#A37ACC",
         "cyan": "#4CBF99",
         "white": "#D1D1D1"

--- a/Ayu Green/Ayu Green.json
+++ b/Ayu Green/Ayu Green.json
@@ -18,8 +18,8 @@
       "normal": {
         "black": "#171B24",
         "red": "#ED8274",
-        "green": "#FACC6E",
-        "yellow": "#87D96C",
+        "green": "#87D96C",
+        "yellow": "#FACC6E",
         "blue": "#6DCBFA",
         "magenta": "#DABAFA",
         "cyan": "#90E1C6",
@@ -28,8 +28,8 @@
       "bright": {
         "black": "#686868",
         "red": "#F28779",
-        "green": "#FFD173",
-        "yellow": "#D5FF80",
+        "green": "#D5FF80",
+        "yellow": "#FFD173",
         "blue": "#73D0FF",
         "magenta": "#DFBFFF",
         "cyan": "#95E6CB",
@@ -64,8 +64,8 @@
       "normal": {
         "black": "#000000",
         "red": "#EA6C6D",
-        "green": "#ECA944",
-        "yellow": "#6CBF43",
+        "green": "#6CBF43",
+        "yellow": "#ECA944",
         "blue": "#3199E1",
         "magenta": "#9E75C7",
         "cyan": "#46BA94",
@@ -74,8 +74,8 @@
       "bright": {
         "black": "#686868",
         "red": "#F07171",
-        "green": "#F2AE49",
-        "yellow": "#86B300",
+        "green": "#86B300",
+        "yellow": "#F2AE49",
         "blue": "#399EE6",
         "magenta": "#A37ACC",
         "cyan": "#4CBF99",

--- a/Ayu Red/Ayu Red.json
+++ b/Ayu Red/Ayu Red.json
@@ -17,9 +17,9 @@
     "terminal": {
       "normal": {
         "black": "#171B24",
-        "red": "#FACC6E",
-        "green": "#ED8274",
-        "yellow": "#87D96C",
+        "red": "#ED8274",
+        "green": "#87D96C",
+        "yellow": "#FACC6E",
         "blue": "#6DCBFA",
         "magenta": "#DABAFA",
         "cyan": "#90E1C6",
@@ -27,9 +27,9 @@
       },
       "bright": {
         "black": "#686868",
-        "red": "#FFD173",
-        "green": "#F28779",
-        "yellow": "#D5FF80",
+        "red": "#F28779",
+        "green": "#D5FF80",
+        "yellow": "#FFD173",
         "blue": "#73D0FF",
         "magenta": "#DFBFFF",
         "cyan": "#95E6CB",
@@ -63,9 +63,9 @@
     "terminal": {
       "normal": {
         "black": "#000000",
-        "red": "#ECA944",
-        "green": "#EA6C6D",
-        "yellow": "#6CBF43",
+        "red": "#EA6C6D",
+        "green": "#6CBF43",
+        "yellow": "#ECA944",
         "blue": "#3199E1",
         "magenta": "#9E75C7",
         "cyan": "#46BA94",
@@ -73,9 +73,9 @@
       },
       "bright": {
         "black": "#686868",
-        "red": "#F2AE49",
-        "green": "#F07171",
-        "yellow": "#86B300",
+        "red": "#F07171",
+        "green": "#86B300",
+        "yellow": "#F2AE49",
         "blue": "#399EE6",
         "magenta": "#A37ACC",
         "cyan": "#4CBF99",


### PR DESCRIPTION
## Description

The Ayu variant themes were incorrectly assigning terminal colors, causing applications which expect that the standard 16 colors map correctly to show incorrect colors (e.g. yellow instead of red for errors).

## Screenshots

Please attach screenshots of your palette applied in Noctalia for both themes:

### Dark theme
<img width="759" height="464" alt="screenshot_20260909_210955-region" src="https://github.com/user-attachments/assets/b3c3e5cc-1b65-4d85-92b0-92a6e03d3edc" />

### Light theme
<img width="761" height="466" alt="screenshot_20260909_211014-region" src="https://github.com/user-attachments/assets/9c49b98b-90c0-46bf-906d-b0c076335f68" />

## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above
