### PR TITLE
fix: swap Kitten primary/secondary/tertiary colors

### DIFF
--- a/Kitten/Kitten.json
+++ b/Kitten/Kitten.json
@@ -1,8 +1,8 @@
 {
   "dark": {
-    "mPrimary": "#737373",
+    "mPrimary": "#b7b7b7",
     "mOnPrimary": "#232323",
-    "mSecondary": "#a7a7a7",
+    "mSecondary": "#939393",
     "mOnSecondary": "#232323",
     "mTertiary": "#999999",
     "mOnTertiary": "#232323",
@@ -46,11 +46,11 @@
     }
   },
   "light": {
-    "mPrimary": "#555555",
+    "mPrimary": "#5d5d5d",
     "mOnPrimary": "#eeeeee",
-    "mSecondary": "#505058",
+    "mSecondary": "#726f6f",
     "mOnSecondary": "#eeeeee",
-    "mTertiary": "#333333",
+    "mTertiary": "#83827e",
     "mOnTertiary": "#eeeeee",
     "mError": "#222222",
     "mOnError": "#efefef",


### PR DESCRIPTION
## Description

Swapped primary/secondary/tertiary colors to a more sensible order for better workspace indicators

## Screenshots

### Dark theme
<img width="1520" height="1077" alt="09-10-2026-02:46:57-annotated" src="https://github.com/user-attachments/assets/747f37ea-a6ee-43c0-bc4b-59bb486f448f" />

### Light theme
<img width="1548" height="1061" alt="09-10-2026-02:46:22-annotated" src="https://github.com/user-attachments/assets/3656f17f-3995-4c17-861c-519f9e43599f" />

## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above
