### PR TITLE
feat(seoul256): add Seoul256 along hard and soft variants

### DIFF
--- a/Seoul256 Hard/Seoul256 Hard.json
+++ b/Seoul256 Hard/Seoul256 Hard.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#d5a55f",
+    "mOnPrimary": "#262626",
+    "mSecondary": "#88b0d5",
+    "mOnSecondary": "#262626",
+    "mTertiary": "#61afac",
+    "mOnTertiary": "#262626",
+    "mError": "#ba3c38",
+    "mOnError": "#d0cfca",
+    "mSurface": "#1c1c1c",
+    "mOnSurface": "#d0d0d0",
+    "mSurfaceVariant": "#262626",
+    "mOnSurfaceVariant": "#dadada",
+    "mOutline": "#626262",
+    "mShadow": "#121212",
+    "mHover": "#d2d6b0",
+    "mOnHover": "#262626",
+    "terminal": {
+      "foreground": "#d0d0d0",
+      "background": "#1c1c1c",
+      "selectionFg": "#c5c8c6",
+      "selectionBg": "#2a6060",
+      "cursorText": "#262626",
+      "cursor": "#c5c8c6",
+      "normal": {
+        "black": "#262626",
+        "red": "#ba3c38",
+        "green": "#5d8760",
+        "yellow": "#d5a55f",
+        "blue": "#78a0c5",
+        "magenta": "#cd5b6d",
+        "cyan": "#61afac",
+        "white": "#d0cfca"
+      },
+      "bright": {
+        "black": "#585858",
+        "red": "#ea7173",
+        "green": "#8ccd99",
+        "yellow": "#d2d6b0",
+        "blue": "#98c7f0",
+        "magenta": "#e599b3",
+        "cyan": "#9cc9c9",
+        "white": "#e0dfda"
+      }
+    }
+  },
+  "light": {
+    "mPrimary": "#a9824b",
+    "mOnPrimary": "#ededed",
+    "mSecondary": "#88b0d5",
+    "mOnSecondary": "#262626",
+    "mTertiary": "#376361",
+    "mOnTertiary": "#d0cfca",
+    "mError": "#ba3c38",
+    "mOnError": "#dadada",
+    "mSurface": "#eeeeee",
+    "mOnSurface": "#444444",
+    "mSurfaceVariant": "#dadada",
+    "mOnSurfaceVariant": "#444444",
+    "mOutline": "#5f5f5f",
+    "mShadow": "#e4e4e4",
+    "mHover": "#f8d58b",
+    "mOnHover": "#262626",
+    "terminal": {
+      "foreground": "#444444",
+      "background": "#eeeeee",
+      "selectionFg": "#444444",
+      "selectionBg": "#b0d7d7",
+      "cursorText": "#eeeeee",
+      "cursor": "#c5c8c6",
+      "normal": {
+        "black": "#434343",
+        "red": "#ba3c38",
+        "green": "#5d8760",
+        "yellow": "#a9824b",
+        "blue": "#78a0c5",
+        "magenta": "#cd5985",
+        "cyan": "#418f8c",
+        "white": "#d0cfca"
+      },
+      "bright": {
+        "black": "#5d5d5d",
+        "red": "#ea615f",
+        "green": "#8ccd99",
+        "yellow": "#f8d58b",
+        "blue": "#98c7f0",
+        "magenta": "#e599b3",
+        "cyan": "#9cc9c9",
+        "white": "#f4f2ec"
+      }
+    }
+  }
+}

--- a/Seoul256 Soft/Seoul256 Soft.json
+++ b/Seoul256 Soft/Seoul256 Soft.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#d5a55f",
+    "mOnPrimary": "#262626",
+    "mSecondary": "#88b0d5",
+    "mOnSecondary": "#262626",
+    "mTertiary": "#61afac",
+    "mOnTertiary": "#262626",
+    "mError": "#ba3c38",
+    "mOnError": "#d0cfca",
+    "mSurface": "#4e4e4e",
+    "mOnSurface": "#d0d0d0",
+    "mSurfaceVariant": "#585858",
+    "mOnSurfaceVariant": "#dadada",
+    "mOutline": "#626262",
+    "mShadow": "#444444",
+    "mHover": "#d2d6b0",
+    "mOnHover": "#262626",
+    "terminal": {
+      "foreground": "#d0d0d0",
+      "background": "#4e4e4e",
+      "selectionFg": "#c5c8c6",
+      "selectionBg": "#2a6060",
+      "cursorText": "#4e4e4e",
+      "cursor": "#c5c8c6",
+      "normal": {
+        "black": "#262626",
+        "red": "#ba3c38",
+        "green": "#5d8760",
+        "yellow": "#d5a55f",
+        "blue": "#78a0c5",
+        "magenta": "#cd5b6d",
+        "cyan": "#61afac",
+        "white": "#d0cfca"
+      },
+      "bright": {
+        "black": "#626262",
+        "red": "#ea7173",
+        "green": "#8ccd99",
+        "yellow": "#d2d6b0",
+        "blue": "#98c7f0",
+        "magenta": "#e599b3",
+        "cyan": "#9cc9c9",
+        "white": "#e0dfda"
+      }
+    }
+  },
+  "light": {
+    "mPrimary": "#a9824b",
+    "mOnPrimary": "#ededed",
+    "mSecondary": "#88b0d5",
+    "mOnSecondary": "#262626",
+    "mTertiary": "#376361",
+    "mOnTertiary": "#d0cfca",
+    "mError": "#ba3c38",
+    "mOnError": "#dadada",
+    "mSurface": "#d0d0d0",
+    "mOnSurface": "#444444",
+    "mSurfaceVariant": "#bcbcbc",
+    "mOnSurfaceVariant": "#444444",
+    "mOutline": "#5f5f5f",
+    "mShadow": "#c6c6c6",
+    "mHover": "#f8d58b",
+    "mOnHover": "#262626",
+    "terminal": {
+      "foreground": "#444444",
+      "background": "#d0d0d0",
+      "selectionFg": "#444444",
+      "selectionBg": "#b0d7d7",
+      "cursorText": "#d0d0d0",
+      "cursor": "#959896",
+      "normal": {
+        "black": "#262626",
+        "red": "#ba3c38",
+        "green": "#5d8760",
+        "yellow": "#a9824b",
+        "blue": "#78a0c5",
+        "magenta": "#cd5985",
+        "cyan": "#418f8c",
+        "white": "#e0dfda"
+      },
+      "bright": {
+        "black": "#626262",
+        "red": "#ea615f",
+        "green": "#8ccd99",
+        "yellow": "#f8d58b",
+        "blue": "#98c7f0",
+        "magenta": "#e599b3",
+        "cyan": "#9cc9c9",
+        "white": "#f4f2ec"
+      }
+    }
+  }
+}

--- a/Seoul256/Seoul256.json
+++ b/Seoul256/Seoul256.json
@@ -1,0 +1,94 @@
+{
+  "dark": {
+    "mPrimary": "#d5a55f",
+    "mOnPrimary": "#262626",
+    "mSecondary": "#88b0d5",
+    "mOnSecondary": "#262626",
+    "mTertiary": "#61afac",
+    "mOnTertiary": "#262626",
+    "mError": "#ba3c38",
+    "mOnError": "#d0cfca",
+    "mSurface": "#3a3a3a",
+    "mOnSurface": "#d0d0d0",
+    "mSurfaceVariant": "#444444",
+    "mOnSurfaceVariant": "#dadada",
+    "mOutline": "#626262",
+    "mShadow": "#3a3a3a",
+    "mHover": "#d2d6b0",
+    "mOnHover": "#262626",
+    "terminal": {
+      "foreground": "#d0d0d0",
+      "background": "#3a3a3a",
+      "selectionFg": "#c5c8c6",
+      "selectionBg": "#2a6060",
+      "cursorText": "#3a3a3a",
+      "cursor": "#c5c8c6",
+      "normal": {
+        "black": "#262626",
+        "red": "#ba3c38",
+        "green": "#5d8760",
+        "yellow": "#d5a55f",
+        "blue": "#78a0c5",
+        "magenta": "#cd5b6d",
+        "cyan": "#61afac",
+        "white": "#d0cfca"
+      },
+      "bright": {
+        "black": "#585858",
+        "red": "#ea7173",
+        "green": "#8ccd99",
+        "yellow": "#d2d6b0",
+        "blue": "#98c7f0",
+        "magenta": "#e599b3",
+        "cyan": "#9cc9c9",
+        "white": "#e0dfda"
+      }
+    }
+  },
+  "light": {
+    "mPrimary": "#a9824b",
+    "mOnPrimary": "#ededed",
+    "mSecondary": "#88b0d5",
+    "mOnSecondary": "#262626",
+    "mTertiary": "#376361",
+    "mOnTertiary": "#d0cfca",
+    "mError": "#ba3c38",
+    "mOnError": "#dadada",
+    "mSurface": "#dadada",
+    "mOnSurface": "#444444",
+    "mSurfaceVariant": "#c6c6c6",
+    "mOnSurfaceVariant": "#444444",
+    "mOutline": "#5f5f5f",
+    "mShadow": "#c6c6c6",
+    "mHover": "#f8d58b",
+    "mOnHover": "#262626",
+    "terminal": {
+      "foreground": "#444444",
+      "background": "#dadada",
+      "selectionFg": "#444444",
+      "selectionBg": "#b0d7d7",
+      "cursorText": "#c5c8c6",
+      "cursor": "#1d1f21",
+      "normal": {
+        "black": "#434343",
+        "red": "#ba3c38",
+        "green": "#5d8760",
+        "yellow": "#a9824b",
+        "blue": "#78a0c5",
+        "magenta": "#cd5985",
+        "cyan": "#418f8c",
+        "white": "#d0cfca"
+      },
+      "bright": {
+        "black": "#5d5d5d",
+        "red": "#ea615f",
+        "green": "#8ccd99",
+        "yellow": "#f8d58b",
+        "blue": "#98c7f0",
+        "magenta": "#e599b3",
+        "cyan": "#9cc9c9",
+        "white": "#f4f2ec"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Initial inspiration came frome the builtin `seoul256` themes in the helix editor.
From there some research about the theme origin lead me throught the [`vim theme`](https://github.com/junegunn/seoul256.vim/) to [it supposed origin](https://www.seoul.go.kr/seoul/color.do). This last url was handed to claude to create a basic set of themes which later where manually refined.
I put some extra effort in fine tuning the terminal colors, since this feels for me like an important and sadly often overlookd part of a theme.

The `hard` and `soft` variants differ mostly in harder or softer surface shades and some minor contrast adjustments.
I have been daily driving this theme the last couple of weeks refining it to the current state.

(If you want me to explicitly split the themes into separate PRs, or want to reject the variants, let me know, I am happy to split or adjust the PR.)

PS: I adjusted `onPrimary` to produce a contrast of 3.0:1 and fixed an issue I overlooked with the `cyan` value

## Screenshots

Please attach screenshots of your palette applied in Noctalia for both themes:

### Dark theme
Seoul 256
<img width="2560" height="1440" alt="screenshot_20260910_122433" src="https://github.com/user-attachments/assets/8a94f8c7-57f4-4e4f-8e5a-df5862e886c0" />

Seoul256 Hard
<img width="2560" height="1440" alt="screenshot_20260910_122505" src="https://github.com/user-attachments/assets/b55a2e62-a96d-4c5e-aa62-462051119561" />

Seoul256 Soft
<img width="2560" height="1440" alt="screenshot_20260910_122528" src="https://github.com/user-attachments/assets/2fb31773-b992-43dc-9357-34ad9f14c612" />

### Light theme
Seoul 256
<img width="2560" height="1440" alt="screenshot_20260910_122425" src="https://github.com/user-attachments/assets/a8d7d062-20d2-4e54-9d28-2fcd19a7d2fa" />

Seoul256 Hard
<img width="2560" height="1440" alt="screenshot_20260910_122455" src="https://github.com/user-attachments/assets/d0d642dd-c930-4ce9-9ca8-f35330e8d5a6" />

Seoul256 Soft
<img width="2560" height="1440" alt="screenshot_20260910_122538" src="https://github.com/user-attachments/assets/3735d5e0-84b4-404b-a2cc-f3c458890b91" />

## Checklist

- [x] I have tested my palette in Noctalia with the **dark** theme
- [x] I have tested my palette in Noctalia with the **light** theme
- [x] Screenshots for both themes are attached above
